### PR TITLE
Resource sslvpn auth rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 BUGFIXES:
 * `fortios_certificate_management_local` and `fortios_certificate_management_remote` will now parse the certificate and check for equality instead of checking strings match. Fixes [#4](https://github.com/poroping/terraform-provider-fortios/issues/4)
 
+FEATURES:
+
+* **New Resource** `fortios_vpnssl_settings_authentication_rule`
+* **Data Source** `fortios_vpnssl_settings_authentication_rule`
+
 ## 2.0.1
 
 * Signed and deployed to Terraform registry.
@@ -27,8 +32,8 @@ FEATURES:
 * **New Resource** `fortios_firewall_access_proxy_virtual_host`
 * **New Resource** `fortios_certificate_management_local`
 * **New Resource** `fortios_certificate_management_remote`
-* **New Data Source** `fortios_system_access_proxy`
-* **New Data Source** `fortios_system_access_proxy_virtual_host`
+* **New Data Source** `fortios_firewall_access_proxy`
+* **New Data Source** `fortios_firewall_access_proxy_virtual_host`
 * **New Data Source** `fortios_system_certificate_download`
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ FEATURES:
 * **New Resource** `fortios_vpnssl_settings_authentication_rule`
 * **Data Source** `fortios_vpnssl_settings_authentication_rule`
 
+IMPROVEMENTS:
+* Codegen templates tidied
+* Codegen support for childtables
+* Codegen support for resources with parent attribute ID. ID is reserved attribute in TF, FOSID is used instead.
+* Codegen support for Sensitive attributes (based on attribute type containing "password")
+
 ## 2.0.1
 
 * Signed and deployed to Terraform registry.

--- a/codegen/apischema/vpnssl_settings_authentication_rule.json
+++ b/codegen/apischema/vpnssl_settings_authentication_rule.json
@@ -1,0 +1,307 @@
+{
+    "http_method": "GET",
+    "revision": "8714c92cd90ec19bf8bbce9afbcdb372",
+    "results": {
+        "name": "authentication-rule",
+        "category": "table",
+        "help": "Authentication rule for SSL VPN.",
+        "mkey": "id",
+        "mkey_type": "integer",
+        "children": {
+            "id": {
+                "name": "id",
+                "category": "unitary",
+                "type": "integer",
+                "help": "ID (0 - 4294967295).",
+                "min-value": 0,
+                "max-value": 4294967295,
+                "default": 0
+            },
+            "source-interface": {
+                "name": "source-interface",
+                "category": "table",
+                "help": "SSL VPN source interface of incoming traffic.",
+                "member_table": true,
+                "mkey": "name",
+                "mkey_type": "string",
+                "children": {
+                    "name": {
+                        "name": "name",
+                        "category": "unitary",
+                        "type": "string",
+                        "help": "Interface name.",
+                        "required": true,
+                        "datasource": [
+                            "system.interface.name",
+                            "system.zone.name"
+                        ],
+                        "size": 35,
+                        "default": ""
+                    }
+                },
+                "max_table_size_vdom": 0,
+                "max_table_size_global": 0,
+                "max_table_size_item": 0
+            },
+            "source-address": {
+                "name": "source-address",
+                "category": "table",
+                "help": "Source address of incoming traffic.",
+                "member_table": true,
+                "mkey": "name",
+                "mkey_type": "string",
+                "children": {
+                    "name": {
+                        "name": "name",
+                        "category": "unitary",
+                        "type": "string",
+                        "help": "Address name.",
+                        "required": true,
+                        "datasource": [
+                            "firewall.address.name",
+                            "firewall.addrgrp.name",
+                            "system.external-resource.name"
+                        ],
+                        "size": 79,
+                        "default": ""
+                    }
+                },
+                "max_table_size_vdom": 0,
+                "max_table_size_global": 0,
+                "max_table_size_item": 0
+            },
+            "source-address-negate": {
+                "name": "source-address-negate",
+                "category": "unitary",
+                "type": "option",
+                "help": "Enable/disable negated source address match.",
+                "multiple_values": false,
+                "options": [
+                    {
+                        "name": "enable",
+                        "help": "Enable setting."
+                    },
+                    {
+                        "name": "disable",
+                        "help": "Disable setting."
+                    }
+                ],
+                "default": "disable"
+            },
+            "source-address6": {
+                "name": "source-address6",
+                "category": "table",
+                "help": "IPv6 source address of incoming traffic.",
+                "member_table": true,
+                "mkey": "name",
+                "mkey_type": "string",
+                "children": {
+                    "name": {
+                        "name": "name",
+                        "category": "unitary",
+                        "type": "string",
+                        "help": "IPv6 address name.",
+                        "required": true,
+                        "datasource": [
+                            "firewall.address6.name",
+                            "firewall.addrgrp6.name",
+                            "system.external-resource.name"
+                        ],
+                        "size": 79,
+                        "default": ""
+                    }
+                },
+                "max_table_size_vdom": 0,
+                "max_table_size_global": 0,
+                "max_table_size_item": 0
+            },
+            "source-address6-negate": {
+                "name": "source-address6-negate",
+                "category": "unitary",
+                "type": "option",
+                "help": "Enable/disable negated source IPv6 address match.",
+                "multiple_values": false,
+                "options": [
+                    {
+                        "name": "enable",
+                        "help": "Enable setting."
+                    },
+                    {
+                        "name": "disable",
+                        "help": "Disable setting."
+                    }
+                ],
+                "default": "disable"
+            },
+            "users": {
+                "name": "users",
+                "category": "table",
+                "help": "User name.",
+                "member_table": true,
+                "mkey": "name",
+                "mkey_type": "string",
+                "children": {
+                    "name": {
+                        "name": "name",
+                        "category": "unitary",
+                        "type": "string",
+                        "help": "User name.",
+                        "required": true,
+                        "datasource": [
+                            "user.local.name"
+                        ],
+                        "size": 79,
+                        "default": ""
+                    }
+                },
+                "max_table_size_vdom": 0,
+                "max_table_size_global": 0,
+                "max_table_size_item": 0
+            },
+            "groups": {
+                "name": "groups",
+                "category": "table",
+                "help": "User groups.",
+                "member_table": true,
+                "mkey": "name",
+                "mkey_type": "string",
+                "children": {
+                    "name": {
+                        "name": "name",
+                        "category": "unitary",
+                        "type": "string",
+                        "help": "Group name.",
+                        "required": true,
+                        "datasource": [
+                            "user.group.name"
+                        ],
+                        "size": 79,
+                        "default": ""
+                    }
+                },
+                "max_table_size_vdom": 0,
+                "max_table_size_global": 0,
+                "max_table_size_item": 0
+            },
+            "portal": {
+                "name": "portal",
+                "category": "unitary",
+                "type": "string",
+                "help": "SSL VPN portal.",
+                "datasource": [
+                    "vpn.ssl.web.portal.name"
+                ],
+                "size": 35,
+                "default": ""
+            },
+            "realm": {
+                "name": "realm",
+                "category": "unitary",
+                "type": "string",
+                "help": "SSL VPN realm.",
+                "datasource": [
+                    "vpn.ssl.web.realm.url-path"
+                ],
+                "size": 35,
+                "default": ""
+            },
+            "client-cert": {
+                "name": "client-cert",
+                "category": "unitary",
+                "type": "option",
+                "help": "Enable/disable SSL VPN client certificate restrictive.",
+                "multiple_values": false,
+                "options": [
+                    {
+                        "name": "enable",
+                        "help": "Enable setting."
+                    },
+                    {
+                        "name": "disable",
+                        "help": "Disable setting."
+                    }
+                ],
+                "default": "disable"
+            },
+            "user-peer": {
+                "name": "user-peer",
+                "category": "unitary",
+                "type": "string",
+                "help": "Name of user peer.",
+                "datasource": [
+                    "user.peer.name"
+                ],
+                "size": 35,
+                "default": ""
+            },
+            "cipher": {
+                "name": "cipher",
+                "category": "unitary",
+                "type": "option",
+                "help": "SSL VPN cipher strength.",
+                "multiple_values": false,
+                "options": [
+                    {
+                        "name": "any",
+                        "help": "Any cipher strength."
+                    },
+                    {
+                        "name": "high",
+                        "help": "High cipher strength (>= 168 bits)."
+                    },
+                    {
+                        "name": "medium",
+                        "help": "Medium cipher strength (>= 128 bits)."
+                    }
+                ],
+                "default": "high"
+            },
+            "auth": {
+                "name": "auth",
+                "category": "unitary",
+                "type": "option",
+                "help": "SSL VPN authentication method restriction.",
+                "multiple_values": false,
+                "options": [
+                    {
+                        "name": "any",
+                        "help": "Any"
+                    },
+                    {
+                        "name": "local",
+                        "help": "Local"
+                    },
+                    {
+                        "name": "radius",
+                        "help": "RADIUS"
+                    },
+                    {
+                        "name": "tacacs+",
+                        "help": "TACACS+"
+                    },
+                    {
+                        "name": "ldap",
+                        "help": "LDAP"
+                    }
+                ],
+                "default": "any"
+            }
+        },
+        "max_table_size_vdom": 5000,
+        "max_table_size_global": 5000,
+        "max_table_size_item": 0,
+        "path": "vpn.ssl",
+        "q_type": 139,
+        "access_group": "vpngrp"
+    },
+    "vdom": "root",
+    "path": "vpn.ssl",
+    "name": "settings",
+    "action": "schema",
+    "child_path": "authentication-rule",
+    "status": "success",
+    "http_status": 200,
+    "serial": "FGT60FTK20028507",
+    "version": "v7.0.0",
+    "build": 66
+}

--- a/codegen/templates/_data_source_docs_arg_reference.gotmpl
+++ b/codegen/templates/_data_source_docs_arg_reference.gotmpl
@@ -1,10 +1,11 @@
 {{ define "DATASOURCEARGREF" }}
 
 ## Argument Reference
+{{ $mkey := .mkey }}
 {{- range $key, $value := .children }}
-{{- if $value.dsrequired }}
+{{- if or (eq $value.name $mkey) ($value.fosid) }}
 * `{{(flatten $value.name)}}` - (Required) {{$value.help}}
+{{- end }}
+{{- end }}
 * `vdomparam` - Specifies the vdom to which the data source will be applied when the FortiGate unit is running in VDOM mode. Only one vdom can be specified. If you want to inherit the vdom configuration of the provider, please do not set this parameter.
-{{- end }}
-{{- end }}
 {{ end }}

--- a/codegen/templates/_data_source_docs_header.gotmpl
+++ b/codegen/templates/_data_source_docs_header.gotmpl
@@ -1,11 +1,11 @@
 {{- define "DATASOURCEDOCSHEADER" }}---
-subcategory: "FortiGate {{ (title .path) }}"
+subcategory: "FortiGate {{ (title (subcategory .path)) }}"
 layout: "fortios"
-page_title: "FortiOS: fortios_{{(flatten .path)}}_{{(flatten .name)}}"
+page_title: "FortiOS: fortios_{{(flatten .path)}}_{{(flatten .name)}}{{if .child_path}}_{{(flatten .child_path)}}{{end}}"
 description: |-
-  Get information on an fortios {{(flatten .path)}} {{.name}}.
+  Get information on a fortios {{.results.help}}
 ---
 
-# Data Source: fortios_{{(flatten .path)}}_{{(flatten .name)}}
-Use this data source to get information on an fortios {{(flatten .path)}} {{(flatten .name)}}
+# Data Source: fortios_{{(flatten .path)}}_{{(flatten .name)}}{{if .child_path}}_{{(flatten .child_path)}}{{end}}
+Use this data source to get information on a fortios {{.results.help}}
 {{ end }}

--- a/codegen/templates/_data_source_flatten.gotmpl
+++ b/codegen/templates/_data_source_flatten.gotmpl
@@ -2,25 +2,7 @@
 {{- range $key, $value := .children }}
 {{- if eq $value.category "unitary" }}
 func dataSourceFlatten{{.fpath}}(v interface{}, d *schema.ResourceData, pre string) interface{} {
-{{- if eq $value.type "ipv4-classnet-any" }}
-	if v1, ok := d.GetOkExists(pre); ok && v != nil {
-		if s, ok := v1.(string); ok {
-			v = validateConvIPMask2CIDR(s, v.(string))
-			return v
-		}
-	}
-	return v
-}
-{{- else if eq $value.type "ipv4-classnet-host" }}
-	if v1, ok := d.GetOkExists(pre); ok && v != nil {
-		if s, ok := v1.(string); ok {
-			v = validateConvIPMask2CIDR(s, v.(string))
-			return v
-		}
-	}
-	return v
-}
-{{- else if eq $value.type "ipv4-classnet" }}
+{{- if or (eq $value.type "ipv4-classnet-any") (eq $value.type "ipv4-classnet-host") (eq $value.type "ipv4-classnet") }}
 	if v1, ok := d.GetOkExists(pre); ok && v != nil {
 		if s, ok := v1.(string); ok {
 			v = validateConvIPMask2CIDR(s, v.(string))
@@ -67,8 +49,8 @@ func dataSourceFlatten{{.fpath}}(v interface{}, d *schema.ResourceData, pre stri
 
 	return result
 }
-{{- template "DSFLATTEN" $value }}
 
+{{ template "DSFLATTEN" $value }}
 {{- end }}
 {{- if eq $value.category "complex" }}
 func dataSourceFlatten{{.fpath}}(v interface{}, d *schema.ResourceData, pre string) []map[string]interface{} {
@@ -103,8 +85,8 @@ func dataSourceFlatten{{.fpath}}(v interface{}, d *schema.ResourceData, pre stri
 
 	return result
 }
-{{- template "DSFLATTEN" $value }}
 
+{{ template "DSFLATTEN" $value }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/codegen/templates/_data_source_refresh_object.gotmpl
+++ b/codegen/templates/_data_source_refresh_object.gotmpl
@@ -1,11 +1,26 @@
-{{define "DSREFRESHOBJECT" }}
+{{ define "DSREFRESHOBJECT" }}
+func dataSourceRefreshObject{{.fpath}}(d *schema.ResourceData, o map[string]interface{}) error {
+	var err error
+{{ template "DSREFRESHOBJECTS" .results }}
+
+	return nil
+}
+{{ end }}
+{{ define "DSREFRESHOBJECTS" }}
 {{- range $key, $value := .children }}
-{{- if $value.category }}
+{{- if and ($value.category) ($value.fosid) }}
+	if err = d.Set({{(flatten $value.name) | printf "%q" }}, dataSourceFlatten{{.fpath}}(o[{{"id" | printf "%q" }}], d, {{(flatten $value.name) | printf "%q" }})); err != nil {
+		if !fortiAPIPatch(o[{{"id" | printf "%q" }}]) {
+			return fmt.Errorf("error reading {{(flatten $value.name)}}: %v", err)
+		}
+	}
+{{ end }}
+{{- if and ($value.category) (not $value.fosid) }}
 	if err = d.Set({{(flatten $value.name) | printf "%q" }}, dataSourceFlatten{{.fpath}}(o[{{$value.name | printf "%q" }}], d, {{(flatten $value.name) | printf "%q" }})); err != nil {
 		if !fortiAPIPatch(o[{{$value.name | printf "%q" }}]) {
 			return fmt.Errorf("error reading {{(flatten $value.name)}}: %v", err)
 		}
 	}
-{{- end }}
+{{ end }}
 {{- end }}
 {{ end }}

--- a/codegen/templates/_data_source_schema.gotmpl
+++ b/codegen/templates/_data_source_schema.gotmpl
@@ -4,7 +4,7 @@
             {{(flatten $value.name) | printf "%q" }}:{
             	{{ (typelookup $value.type) }}
                 Description: {{ $value.help | printf "%q" }},
-				{{- if $value.dsrequired }}
+				{{- if $value.schema_required }}
                 Required:     true,
 				{{- else }}
                 Computed:     true,

--- a/codegen/templates/_resource_create_func.gotmpl
+++ b/codegen/templates/_resource_create_func.gotmpl
@@ -57,7 +57,7 @@ func resource{{.fpath}}Create(d *schema.ResourceData, m interface{}) error {
 		o, err = c.Create{{.fpath}}(obj, vdomparam, urlparams, batchid)
 	}
 {{else}}
-	o, err = c.Create{{.fpath}}(obj, vdomparam, urlparams, batchid)
+	o, err := c.Create{{.fpath}}(obj, vdomparam, urlparams, batchid)
 {{end}}
 	if err != nil {
 		return fmt.Errorf("error creating {{.fpath}} resource: %v", err)

--- a/codegen/templates/_resource_docs_attr_reference.gotmpl
+++ b/codegen/templates/_resource_docs_attr_reference.gotmpl
@@ -6,10 +6,10 @@ In addition to all the above arguments, the following attributes are exported:
 
 ## Import
 
-Firewall Address can be imported using any of these accepted formats:
+{{ (title .path) }} can be imported using any of these accepted formats:
 ```
 $ export "FORTIOS_IMPORT_TABLE"="true"
-$ terraform import fortios_firewall_address.labelname {{`{{name}}`}}
+$ terraform import fortios_{{(flatten .path)}}_{{(flatten .name)}}.labelname {{`{{name}}`}}
 $ unset "FORTIOS_IMPORT_TABLE"
 ```
 {{ end }}

--- a/codegen/templates/_resource_docs_header.gotmpl
+++ b/codegen/templates/_resource_docs_header.gotmpl
@@ -1,11 +1,15 @@
 {{- define "RESOURCEDOCSHEADER" }}---
-subcategory: "FortiGate {{ (title .path) }}"
+subcategory: "FortiGate {{ (title (subcategory .path)) }}"
 layout: "fortios"
-page_title: "FortiOS: fortios_{{(flatten .path)}}_{{(flatten .name)}}"
+page_title: "FortiOS: fortios_{{(flatten .path)}}_{{(flatten .name)}}{{if .child_path}}_{{(flatten .child_path)}}{{end}}"
 description: |-
   {{.results.help}}
 ---
 
-## fortios_{{(flatten .path)}}_{{(flatten .name)}}
+## fortios_{{(flatten .path)}}_{{(flatten .name)}}{{if .child_path}}_{{(flatten .child_path)}}{{end}}
 {{.results.help}}
+{{- if .child_path }}
+
+~> This resource is configuring a child table of the parent resource: `fortios_{{(flatten .path)}}_{{(flatten .name)}}`. If this resource is used the parent resource must NOT modify this child table or state inconsistencies will occur.
+{{ end -}}
 {{ end }}

--- a/codegen/templates/_resource_flatten.gotmpl
+++ b/codegen/templates/_resource_flatten.gotmpl
@@ -2,25 +2,7 @@
 {{- range $key, $value := .children }}
 {{- if eq $value.category "unitary" }}
 func flatten{{.fpath}}(v interface{}, d *schema.ResourceData, pre string, sv string) interface{} {
-{{- if eq $value.type "ipv4-classnet-any" }}
-	if v1, ok := d.GetOkExists(pre); ok && v != nil {
-		if s, ok := v1.(string); ok {
-			v = validateConvIPMask2CIDR(s, v.(string))
-			return v
-		}
-	}
-	return v
-}
-{{- else if eq $value.type "ipv4-classnet-host" }}
-	if v1, ok := d.GetOkExists(pre); ok && v != nil {
-		if s, ok := v1.(string); ok {
-			v = validateConvIPMask2CIDR(s, v.(string))
-			return v
-		}
-	}
-	return v
-}
-{{- else if eq $value.type "ipv4-classnet" }}
+{{- if or (eq $value.type "ipv4-classnet-any") (eq $value.type "ipv4-classnet-host") (eq $value.type "ipv4-classnet")}}
 	if v1, ok := d.GetOkExists(pre); ok && v != nil {
 		if s, ok := v1.(string); ok {
 			v = validateConvIPMask2CIDR(s, v.(string))
@@ -68,7 +50,8 @@ func flatten{{.fpath}}(v interface{}, d *schema.ResourceData, pre string, sv str
 	dynamic_sort_subtable(result, "{{ $value.mkey }}", d)
 	return result
 }
-{{- template "FLATTEN" $value }}
+
+{{ template "FLATTEN" $value }}
 
 {{- end }}
 {{- if eq $value.category "complex" }}
@@ -104,7 +87,8 @@ func flatten{{.fpath}}(v interface{}, d *schema.ResourceData, pre string, sv str
 
 	return result
 }
-{{- template "FLATTEN" $value }}
+
+{{ template "FLATTEN" $value }}
 
 {{- end }}
 {{- end }}

--- a/codegen/templates/_resource_get_object.gotmpl
+++ b/codegen/templates/_resource_get_object.gotmpl
@@ -1,7 +1,23 @@
-{{define "GETOBJECT" }}
+{{ define "GETOBJECT" }}
+func getObject{{.fpath}}(d *schema.ResourceData, sv string) (*map[string]interface{}, error) {
+	obj := make(map[string]interface{})
+{{ template "GETOBJECTS" .results}}
+	return &obj, nil
+}
+{{ end }}
+{{ define "GETOBJECTS" }}
 {{- range $key, $value := .children }}
+{{ if $value.fosid }}
 	if v, ok := d.GetOk({{(flatten $value.name) | printf "%q" }}); ok {
-
+		t, err := expand{{.fpath}}(d, v, {{(flatten $value.name) | printf "%q" }}, sv)
+		if err != nil {
+			return &obj, err
+		} else if t != nil {
+			obj[{{"id" | printf "%q" }}] = t
+		}
+	}
+{{- else }}
+	if v, ok := d.GetOk({{(flatten $value.name) | printf "%q" }}); ok {
 		t, err := expand{{.fpath}}(d, v, {{(flatten $value.name) | printf "%q" }}, sv)
 		if err != nil {
 			return &obj, err
@@ -9,5 +25,6 @@
 			obj[{{$value.name | printf "%q" }}] = t
 		}
 	}
-{{- end}}
-{{end}}
+{{ end }}
+{{- end }}
+{{ end }}

--- a/codegen/templates/_resource_refresh_object.gotmpl
+++ b/codegen/templates/_resource_refresh_object.gotmpl
@@ -1,12 +1,29 @@
-{{define "REFRESHOBJECT" }}
+{{ define "REFRESHOBJECT" }}
+func refreshObject{{.fpath}}(d *schema.ResourceData, o map[string]interface{}, sv string) error {
+	var err error
+{{ template "REFRESHOBJECTS" .results }}
+
+	return nil
+}
+{{ end }}
+
+
+{{define "REFRESHOBJECTS" }}
 {{- range $key, $value := .children }}
-{{- if eq $value.category "unitary" }}
+{{- if and (eq $value.category "unitary") ($value.fosid) }}
+	if err = d.Set({{(flatten $value.name) | printf "%q" }}, flatten{{.fpath}}(o[{{"id" | printf "%q" }}], d, {{(flatten $value.name) | printf "%q" }}, sv)); err != nil {
+		if !fortiAPIPatch(o[{{"id" | printf "%q" }}]) {
+			return fmt.Errorf("error reading {{(flatten $value.name)}}: %v", err)
+		}
+	}
+{{ end }}
+{{- if and (eq $value.category "unitary") (not $value.fosid) }}
 	if err = d.Set({{(flatten $value.name) | printf "%q" }}, flatten{{.fpath}}(o[{{$value.name | printf "%q" }}], d, {{(flatten $value.name) | printf "%q" }}, sv)); err != nil {
 		if !fortiAPIPatch(o[{{$value.name | printf "%q" }}]) {
 			return fmt.Errorf("error reading {{(flatten $value.name)}}: %v", err)
 		}
 	}
-{{- end }}
+{{ end }}
 {{- if eq $value.category "table" }}
 	if isImportTable() {
 		if err = d.Set({{(flatten $value.name) | printf "%q" }}, flatten{{.fpath}}(o[{{$value.name | printf "%q" }}], d, {{(flatten $value.name) | printf "%q" }}, sv)); err != nil {

--- a/codegen/templates/_resource_schema.gotmpl
+++ b/codegen/templates/_resource_schema.gotmpl
@@ -5,7 +5,7 @@
             	{{ (typelookup $value.type) }}
 				{{ (valilookup $value) }}
                 Description: {{ $value.help | printf "%q" }},
-                {{- if $value.dsrequired }}
+                {{- if $value.schema_required }}
                 ForceNew: true,
                 Required: true,
                 {{- else }}

--- a/codegen/templates/data_source.gotmpl
+++ b/codegen/templates/data_source.gotmpl
@@ -1,5 +1,5 @@
-{{define "data_source"}}
-{{template "HEADER" .}}
+{{ define "data_source" }}
+{{ template "HEADER" . }}
 
 
 package fortios
@@ -30,11 +30,6 @@ func dataSource{{.fpath}}() *schema.Resource {
 
 {{ template "DSFLATTEN" .results }}
 
-func dataSourceRefreshObject{{.fpath}}(d *schema.ResourceData, o map[string]interface{}) error {
-	var err error
-{{ template "DSREFRESHOBJECT" .results }}
+{{ template "DSREFRESHOBJECT" . }}
 
-	return nil
-}
-
-{{end}}
+{{ end }}

--- a/codegen/templates/resource.gotmpl
+++ b/codegen/templates/resource.gotmpl
@@ -67,21 +67,11 @@ func resource{{.fpath}}() *schema.Resource {
 
 {{ template "FLATTEN" .results }}
 
-func refreshObject{{.fpath}}(d *schema.ResourceData, o map[string]interface{}, sv string) error {
-	var err error
-{{ template "REFRESHOBJECT" .results }}
-
-	return nil
-}
+{{ template "REFRESHOBJECT" . }}
 
 {{ template "EXPAND" .results }}
 
-func getObject{{.fpath}}(d *schema.ResourceData, sv string) (*map[string]interface{}, error) {
-	obj := make(map[string]interface{})
-{{ template "GETOBJECT" .results }}
-	return &obj, nil
-}
-
+{{ template "GETOBJECT" . }}
 
 
 

--- a/fortios/data_source_vpnssl_settings_authentication_rule.go
+++ b/fortios/data_source_vpnssl_settings_authentication_rule.go
@@ -1,0 +1,495 @@
+// Inspired by Official Fortinet Provider https://github.com/fortinetdev/terraform-provider-fortios
+// Shout out to: Frank Shen (@frankshen01), Hongbin Lu (@fgtdev-hblu)
+// Generated from template using FortiOS v7.0.0 schema
+// Template Authors:
+// Justin Roberts (@poroping)
+
+// Description: Authentication rule for SSL VPN.
+
+package fortios
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+)
+
+func dataSourceVpnsslAuthenticationRule() *schema.Resource {
+	return &schema.Resource{
+		Read: dataSourceVpnsslAuthenticationRuleRead,
+		Schema: map[string]*schema.Schema{
+			"vdomparam": {
+				Type:        schema.TypeString,
+				Description: "Specifies the vdom to which the resource will be applied when the FortiGate unit is running in VDOM mode. Only one vdom can be specified. If you want to inherit the vdom configuration of the provider, please do not set this parameter.",
+				Optional:    true,
+				ForceNew:    true,
+			},
+			"auth": {
+				Type:        schema.TypeString,
+				Description: "SSL VPN authentication method restriction.",
+				Computed:    true,
+			},
+			"cipher": {
+				Type:        schema.TypeString,
+				Description: "SSL VPN cipher strength.",
+				Computed:    true,
+			},
+			"client_cert": {
+				Type:        schema.TypeString,
+				Description: "Enable/disable SSL VPN client certificate restrictive.",
+				Computed:    true,
+			},
+			"groups": {
+				Type:        schema.TypeList,
+				Description: "User groups.",
+				Computed:    true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:        schema.TypeString,
+							Description: "Group name.",
+							Computed:    true,
+						},
+					},
+				},
+			},
+			"fosid": {
+				Type:        schema.TypeInt,
+				Description: "ID (0 - 4294967295).",
+				Computed:    true,
+			},
+			"portal": {
+				Type:        schema.TypeString,
+				Description: "SSL VPN portal.",
+				Computed:    true,
+			},
+			"realm": {
+				Type:        schema.TypeString,
+				Description: "SSL VPN realm.",
+				Computed:    true,
+			},
+			"source_address": {
+				Type:        schema.TypeList,
+				Description: "Source address of incoming traffic.",
+				Computed:    true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:        schema.TypeString,
+							Description: "Address name.",
+							Computed:    true,
+						},
+					},
+				},
+			},
+			"source_address_negate": {
+				Type:        schema.TypeString,
+				Description: "Enable/disable negated source address match.",
+				Computed:    true,
+			},
+			"source_address6": {
+				Type:        schema.TypeList,
+				Description: "IPv6 source address of incoming traffic.",
+				Computed:    true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:        schema.TypeString,
+							Description: "IPv6 address name.",
+							Computed:    true,
+						},
+					},
+				},
+			},
+			"source_address6_negate": {
+				Type:        schema.TypeString,
+				Description: "Enable/disable negated source IPv6 address match.",
+				Computed:    true,
+			},
+			"source_interface": {
+				Type:        schema.TypeList,
+				Description: "SSL VPN source interface of incoming traffic.",
+				Computed:    true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:        schema.TypeString,
+							Description: "Interface name.",
+							Computed:    true,
+						},
+					},
+				},
+			},
+			"user_peer": {
+				Type:        schema.TypeString,
+				Description: "Name of user peer.",
+				Computed:    true,
+			},
+			"users": {
+				Type:        schema.TypeList,
+				Description: "User name.",
+				Computed:    true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:        schema.TypeString,
+							Description: "User name.",
+							Computed:    true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func dataSourceVpnsslAuthenticationRuleRead(d *schema.ResourceData, m interface{}) error {
+	c := m.(*FortiClient).Client
+	c.Retries = 1
+	urlparams := make(map[string][]string)
+
+	vdomparam := ""
+
+	if v, ok := d.GetOk("vdomparam"); ok {
+		if s, ok := v.(string); ok {
+			vdomparam = s
+		}
+	}
+
+	mkey := ""
+	key := "id"
+	t := d.Get(key)
+	if v, ok := t.(string); ok {
+		mkey = v
+	} else if v, ok := t.(int); ok {
+		mkey = strconv.Itoa(v)
+	} else {
+		return fmt.Errorf("error describing VpnsslAuthenticationRule: type error")
+	}
+
+	o, err := c.ReadVpnsslAuthenticationRule(mkey, vdomparam, urlparams, 0)
+	if err != nil {
+		return fmt.Errorf("error describing VpnsslAuthenticationRule: %v", err)
+	}
+
+	if o == nil {
+		d.SetId("")
+		return nil
+	}
+
+	err = dataSourceRefreshObjectVpnsslAuthenticationRule(d, o)
+	if err != nil {
+		return fmt.Errorf("error describing VpnsslAuthenticationRule from API: %v", err)
+	}
+
+	d.SetId(mkey)
+
+	return nil
+}
+
+func dataSourceFlattenVpnsslAuthenticationRuleAuth(v interface{}, d *schema.ResourceData, pre string) interface{} {
+	return v
+}
+
+func dataSourceFlattenVpnsslAuthenticationRuleCipher(v interface{}, d *schema.ResourceData, pre string) interface{} {
+	return v
+}
+
+func dataSourceFlattenVpnsslAuthenticationRuleClientCert(v interface{}, d *schema.ResourceData, pre string) interface{} {
+	return v
+}
+
+func dataSourceFlattenVpnsslAuthenticationRuleGroups(v interface{}, d *schema.ResourceData, pre string) []map[string]interface{} {
+	if v == nil {
+		return nil
+	}
+
+	l := v.([]interface{})
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(l))
+
+	con := 0
+	for _, r := range l {
+		tmp := make(map[string]interface{})
+		i := r.(map[string]interface{})
+
+		pre_append := "" // table
+		pre_append = pre + "." + strconv.Itoa(con) + "." + "name"
+		if _, ok := i["name"]; ok {
+
+			tmp["name"] = dataSourceFlattenVpnsslAuthenticationRuleGroupsName(i["name"], d, pre_append)
+		}
+
+		result = append(result, tmp)
+
+		con += 1
+	}
+
+	return result
+}
+
+func dataSourceFlattenVpnsslAuthenticationRuleGroupsName(v interface{}, d *schema.ResourceData, pre string) interface{} {
+	return v
+}
+
+func dataSourceFlattenVpnsslAuthenticationRuleId(v interface{}, d *schema.ResourceData, pre string) interface{} {
+	return v
+}
+
+func dataSourceFlattenVpnsslAuthenticationRulePortal(v interface{}, d *schema.ResourceData, pre string) interface{} {
+	return v
+}
+
+func dataSourceFlattenVpnsslAuthenticationRuleRealm(v interface{}, d *schema.ResourceData, pre string) interface{} {
+	return v
+}
+
+func dataSourceFlattenVpnsslAuthenticationRuleSourceAddress(v interface{}, d *schema.ResourceData, pre string) []map[string]interface{} {
+	if v == nil {
+		return nil
+	}
+
+	l := v.([]interface{})
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(l))
+
+	con := 0
+	for _, r := range l {
+		tmp := make(map[string]interface{})
+		i := r.(map[string]interface{})
+
+		pre_append := "" // table
+		pre_append = pre + "." + strconv.Itoa(con) + "." + "name"
+		if _, ok := i["name"]; ok {
+
+			tmp["name"] = dataSourceFlattenVpnsslAuthenticationRuleSourceAddressName(i["name"], d, pre_append)
+		}
+
+		result = append(result, tmp)
+
+		con += 1
+	}
+
+	return result
+}
+
+func dataSourceFlattenVpnsslAuthenticationRuleSourceAddressName(v interface{}, d *schema.ResourceData, pre string) interface{} {
+	return v
+}
+
+func dataSourceFlattenVpnsslAuthenticationRuleSourceAddressNegate(v interface{}, d *schema.ResourceData, pre string) interface{} {
+	return v
+}
+
+func dataSourceFlattenVpnsslAuthenticationRuleSourceAddress6(v interface{}, d *schema.ResourceData, pre string) []map[string]interface{} {
+	if v == nil {
+		return nil
+	}
+
+	l := v.([]interface{})
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(l))
+
+	con := 0
+	for _, r := range l {
+		tmp := make(map[string]interface{})
+		i := r.(map[string]interface{})
+
+		pre_append := "" // table
+		pre_append = pre + "." + strconv.Itoa(con) + "." + "name"
+		if _, ok := i["name"]; ok {
+
+			tmp["name"] = dataSourceFlattenVpnsslAuthenticationRuleSourceAddress6Name(i["name"], d, pre_append)
+		}
+
+		result = append(result, tmp)
+
+		con += 1
+	}
+
+	return result
+}
+
+func dataSourceFlattenVpnsslAuthenticationRuleSourceAddress6Name(v interface{}, d *schema.ResourceData, pre string) interface{} {
+	return v
+}
+
+func dataSourceFlattenVpnsslAuthenticationRuleSourceAddress6Negate(v interface{}, d *schema.ResourceData, pre string) interface{} {
+	return v
+}
+
+func dataSourceFlattenVpnsslAuthenticationRuleSourceInterface(v interface{}, d *schema.ResourceData, pre string) []map[string]interface{} {
+	if v == nil {
+		return nil
+	}
+
+	l := v.([]interface{})
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(l))
+
+	con := 0
+	for _, r := range l {
+		tmp := make(map[string]interface{})
+		i := r.(map[string]interface{})
+
+		pre_append := "" // table
+		pre_append = pre + "." + strconv.Itoa(con) + "." + "name"
+		if _, ok := i["name"]; ok {
+
+			tmp["name"] = dataSourceFlattenVpnsslAuthenticationRuleSourceInterfaceName(i["name"], d, pre_append)
+		}
+
+		result = append(result, tmp)
+
+		con += 1
+	}
+
+	return result
+}
+
+func dataSourceFlattenVpnsslAuthenticationRuleSourceInterfaceName(v interface{}, d *schema.ResourceData, pre string) interface{} {
+	return v
+}
+
+func dataSourceFlattenVpnsslAuthenticationRuleUserPeer(v interface{}, d *schema.ResourceData, pre string) interface{} {
+	return v
+}
+
+func dataSourceFlattenVpnsslAuthenticationRuleUsers(v interface{}, d *schema.ResourceData, pre string) []map[string]interface{} {
+	if v == nil {
+		return nil
+	}
+
+	l := v.([]interface{})
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(l))
+
+	con := 0
+	for _, r := range l {
+		tmp := make(map[string]interface{})
+		i := r.(map[string]interface{})
+
+		pre_append := "" // table
+		pre_append = pre + "." + strconv.Itoa(con) + "." + "name"
+		if _, ok := i["name"]; ok {
+
+			tmp["name"] = dataSourceFlattenVpnsslAuthenticationRuleUsersName(i["name"], d, pre_append)
+		}
+
+		result = append(result, tmp)
+
+		con += 1
+	}
+
+	return result
+}
+
+func dataSourceFlattenVpnsslAuthenticationRuleUsersName(v interface{}, d *schema.ResourceData, pre string) interface{} {
+	return v
+}
+
+func dataSourceRefreshObjectVpnsslAuthenticationRule(d *schema.ResourceData, o map[string]interface{}) error {
+	var err error
+
+	if err = d.Set("auth", dataSourceFlattenVpnsslAuthenticationRuleAuth(o["auth"], d, "auth")); err != nil {
+		if !fortiAPIPatch(o["auth"]) {
+			return fmt.Errorf("error reading auth: %v", err)
+		}
+	}
+
+	if err = d.Set("cipher", dataSourceFlattenVpnsslAuthenticationRuleCipher(o["cipher"], d, "cipher")); err != nil {
+		if !fortiAPIPatch(o["cipher"]) {
+			return fmt.Errorf("error reading cipher: %v", err)
+		}
+	}
+
+	if err = d.Set("client_cert", dataSourceFlattenVpnsslAuthenticationRuleClientCert(o["client-cert"], d, "client_cert")); err != nil {
+		if !fortiAPIPatch(o["client-cert"]) {
+			return fmt.Errorf("error reading client_cert: %v", err)
+		}
+	}
+
+	if err = d.Set("groups", dataSourceFlattenVpnsslAuthenticationRuleGroups(o["groups"], d, "groups")); err != nil {
+		if !fortiAPIPatch(o["groups"]) {
+			return fmt.Errorf("error reading groups: %v", err)
+		}
+	}
+
+	if err = d.Set("fosid", dataSourceFlattenVpnsslAuthenticationRuleId(o["id"], d, "fosid")); err != nil {
+		if !fortiAPIPatch(o["id"]) {
+			return fmt.Errorf("error reading fosid: %v", err)
+		}
+	}
+
+	if err = d.Set("portal", dataSourceFlattenVpnsslAuthenticationRulePortal(o["portal"], d, "portal")); err != nil {
+		if !fortiAPIPatch(o["portal"]) {
+			return fmt.Errorf("error reading portal: %v", err)
+		}
+	}
+
+	if err = d.Set("realm", dataSourceFlattenVpnsslAuthenticationRuleRealm(o["realm"], d, "realm")); err != nil {
+		if !fortiAPIPatch(o["realm"]) {
+			return fmt.Errorf("error reading realm: %v", err)
+		}
+	}
+
+	if err = d.Set("source_address", dataSourceFlattenVpnsslAuthenticationRuleSourceAddress(o["source-address"], d, "source_address")); err != nil {
+		if !fortiAPIPatch(o["source-address"]) {
+			return fmt.Errorf("error reading source_address: %v", err)
+		}
+	}
+
+	if err = d.Set("source_address_negate", dataSourceFlattenVpnsslAuthenticationRuleSourceAddressNegate(o["source-address-negate"], d, "source_address_negate")); err != nil {
+		if !fortiAPIPatch(o["source-address-negate"]) {
+			return fmt.Errorf("error reading source_address_negate: %v", err)
+		}
+	}
+
+	if err = d.Set("source_address6", dataSourceFlattenVpnsslAuthenticationRuleSourceAddress6(o["source-address6"], d, "source_address6")); err != nil {
+		if !fortiAPIPatch(o["source-address6"]) {
+			return fmt.Errorf("error reading source_address6: %v", err)
+		}
+	}
+
+	if err = d.Set("source_address6_negate", dataSourceFlattenVpnsslAuthenticationRuleSourceAddress6Negate(o["source-address6-negate"], d, "source_address6_negate")); err != nil {
+		if !fortiAPIPatch(o["source-address6-negate"]) {
+			return fmt.Errorf("error reading source_address6_negate: %v", err)
+		}
+	}
+
+	if err = d.Set("source_interface", dataSourceFlattenVpnsslAuthenticationRuleSourceInterface(o["source-interface"], d, "source_interface")); err != nil {
+		if !fortiAPIPatch(o["source-interface"]) {
+			return fmt.Errorf("error reading source_interface: %v", err)
+		}
+	}
+
+	if err = d.Set("user_peer", dataSourceFlattenVpnsslAuthenticationRuleUserPeer(o["user-peer"], d, "user_peer")); err != nil {
+		if !fortiAPIPatch(o["user-peer"]) {
+			return fmt.Errorf("error reading user_peer: %v", err)
+		}
+	}
+
+	if err = d.Set("users", dataSourceFlattenVpnsslAuthenticationRuleUsers(o["users"], d, "users")); err != nil {
+		if !fortiAPIPatch(o["users"]) {
+			return fmt.Errorf("error reading users: %v", err)
+		}
+	}
+
+	return nil
+}

--- a/fortios/provider.go
+++ b/fortios/provider.go
@@ -315,6 +315,7 @@ func Provider() terraform.ResourceProvider {
 			"fortios_system_certificate_download":             dataSourceSystemCertificateDownload(),
 			"fortios_firewall_access_proxy":                   dataSourceFirewallAccessProxy(),
 			"fortios_firewall_access_proxy_virtual_host":      dataSourceFirewallAccessProxyVirtualHost(),
+			"data_source_vpnssl_settings_authentication_rule": dataSourceVpnsslAuthenticationRule(),
 		},
 
 		ResourcesMap: map[string]*schema.Resource{
@@ -876,6 +877,7 @@ func Provider() terraform.ResourceProvider {
 			"fortios_system_batch_commit":                               resourceSystemBatchCommit(),
 			"fortios_firewall_access_proxy":                             resourceFirewallAccessProxy(),
 			"fortios_firewall_access_proxy_virtual_host":                resourceFirewallAccessProxyVirtualHost(),
+			"fortios_vpnssl_settings_authentication_rule":               resourceVpnsslAuthenticationRule(),
 		},
 
 		ConfigureFunc: providerConfigure,

--- a/fortios/resource_vpnssl_settings_authentication_rule.go
+++ b/fortios/resource_vpnssl_settings_authentication_rule.go
@@ -1,0 +1,1039 @@
+// Inspired by Official Fortinet Provider https://github.com/fortinetdev/terraform-provider-fortios
+// Shout out to: Frank Shen (@frankshen01), Hongbin Lu (@fgtdev-hblu)
+// Generated from template using FortiOS v7.0.0 schema
+// Template Authors:
+// Justin Roberts (@poroping)
+
+// Description: Authentication rule for SSL VPN.
+
+package fortios
+
+import (
+	"fmt"
+	"log"
+	"strconv"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
+)
+
+func resourceVpnsslAuthenticationRule() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceVpnsslAuthenticationRuleCreate,
+		Read:   resourceVpnsslAuthenticationRuleRead,
+		Update: resourceVpnsslAuthenticationRuleUpdate,
+		Delete: resourceVpnsslAuthenticationRuleDelete,
+
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"vdomparam": {
+				Type:        schema.TypeString,
+				Description: "Specifies the vdom to which the resource will be applied when the FortiGate unit is running in VDOM mode. Only one vdom can be specified. If you want to inherit the vdom configuration of the provider, please do not set this parameter.",
+				Optional:    true,
+				ForceNew:    true,
+			},
+			"batchid": {
+				Type:        schema.TypeInt,
+				Description: "Associate with batch. From 6.4.x+. Currently a WIP and broken.",
+				Optional:    true,
+				Default:     0,
+			},
+			"dynamic_sort_table": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+			},
+			"auth": {
+				Type:         schema.TypeString,
+				ValidateFunc: fortiValidateEnum([]string{"any", "local", "radius", "tacacs+", "ldap"}),
+				Description:  "SSL VPN authentication method restriction.",
+				Optional:     true,
+				Computed:     true,
+			},
+			"cipher": {
+				Type:         schema.TypeString,
+				ValidateFunc: fortiValidateEnum([]string{"any", "high", "medium"}),
+				Description:  "SSL VPN cipher strength.",
+				Optional:     true,
+				Computed:     true,
+			},
+			"client_cert": {
+				Type:         schema.TypeString,
+				ValidateFunc: fortiValidateEnableDisable(),
+				Description:  "Enable/disable SSL VPN client certificate restrictive.",
+				Optional:     true,
+				Computed:     true,
+			},
+			"groups": {
+				Type:        schema.TypeList,
+				Description: "User groups.",
+				Optional:    true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:         schema.TypeString,
+							ValidateFunc: validation.StringLenBetween(0, 79),
+							Description:  "Group name.",
+							Optional:     true,
+							Computed:     true,
+						},
+					},
+				},
+			},
+			"fosid": {
+				Type: schema.TypeInt,
+
+				Description: "ID (0 - 4294967295).",
+				Optional:    true,
+				Computed:    true,
+			},
+			"portal": {
+				Type:         schema.TypeString,
+				ValidateFunc: validation.StringLenBetween(0, 35),
+				Description:  "SSL VPN portal.",
+				Optional:     true,
+				Computed:     true,
+			},
+			"realm": {
+				Type:         schema.TypeString,
+				ValidateFunc: validation.StringLenBetween(0, 35),
+				Description:  "SSL VPN realm.",
+				Optional:     true,
+				Computed:     true,
+			},
+			"source_address": {
+				Type:        schema.TypeList,
+				Description: "Source address of incoming traffic.",
+				Optional:    true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:         schema.TypeString,
+							ValidateFunc: validation.StringLenBetween(0, 79),
+							Description:  "Address name.",
+							Optional:     true,
+							Computed:     true,
+						},
+					},
+				},
+			},
+			"source_address_negate": {
+				Type:         schema.TypeString,
+				ValidateFunc: fortiValidateEnableDisable(),
+				Description:  "Enable/disable negated source address match.",
+				Optional:     true,
+				Computed:     true,
+			},
+			"source_address6": {
+				Type:        schema.TypeList,
+				Description: "IPv6 source address of incoming traffic.",
+				Optional:    true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:         schema.TypeString,
+							ValidateFunc: validation.StringLenBetween(0, 79),
+							Description:  "IPv6 address name.",
+							Optional:     true,
+							Computed:     true,
+						},
+					},
+				},
+			},
+			"source_address6_negate": {
+				Type:         schema.TypeString,
+				ValidateFunc: fortiValidateEnableDisable(),
+				Description:  "Enable/disable negated source IPv6 address match.",
+				Optional:     true,
+				Computed:     true,
+			},
+			"source_interface": {
+				Type:        schema.TypeList,
+				Description: "SSL VPN source interface of incoming traffic.",
+				Optional:    true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:         schema.TypeString,
+							ValidateFunc: validation.StringLenBetween(0, 35),
+							Description:  "Interface name.",
+							Optional:     true,
+							Computed:     true,
+						},
+					},
+				},
+			},
+			"user_peer": {
+				Type:         schema.TypeString,
+				ValidateFunc: validation.StringLenBetween(0, 35),
+				Description:  "Name of user peer.",
+				Optional:     true,
+				Computed:     true,
+			},
+			"users": {
+				Type:        schema.TypeList,
+				Description: "User name.",
+				Optional:    true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"name": {
+							Type:         schema.TypeString,
+							ValidateFunc: validation.StringLenBetween(0, 79),
+							Description:  "User name.",
+							Optional:     true,
+							Computed:     true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func resourceVpnsslAuthenticationRuleCreate(d *schema.ResourceData, m interface{}) error {
+	c := m.(*FortiClient).Client
+	c.Retries = 1
+	urlparams := make(map[string][]string)
+
+	vdomparam := ""
+
+	if v, ok := d.GetOk("vdomparam"); ok {
+		if s, ok := v.(string); ok {
+			vdomparam = s
+		}
+	}
+
+	batchid := 0
+
+	if v, ok := d.GetOk("batchid"); ok {
+		if i, ok := v.(int); ok {
+			batchid = i
+		}
+	}
+
+	obj, err := getObjectVpnsslAuthenticationRule(d, c.Fv)
+	if err != nil {
+		return fmt.Errorf("error creating VpnsslAuthenticationRule resource while getting object: %v", err)
+	}
+
+	o, err := c.CreateVpnsslAuthenticationRule(obj, vdomparam, urlparams, batchid)
+
+	if err != nil {
+		return fmt.Errorf("error creating VpnsslAuthenticationRule resource: %v", err)
+	}
+
+	if o["mkey"] != nil && o["mkey"] != "" {
+		d.SetId(strconv.Itoa(int(o["mkey"].(float64))))
+	} else {
+		d.SetId("VpnsslAuthenticationRule")
+	}
+
+	return resourceVpnsslAuthenticationRuleRead(d, m)
+}
+
+func resourceVpnsslAuthenticationRuleUpdate(d *schema.ResourceData, m interface{}) error {
+	mkey := d.Id()
+	c := m.(*FortiClient).Client
+	c.Retries = 1
+	urlparams := make(map[string][]string)
+
+	vdomparam := ""
+
+	if v, ok := d.GetOk("vdomparam"); ok {
+		if s, ok := v.(string); ok {
+			vdomparam = s
+		}
+	}
+
+	batchid := 0
+
+	if v, ok := d.GetOk("batchid"); ok {
+		if i, ok := v.(int); ok {
+			batchid = i
+		}
+	}
+
+	obj, err := getObjectVpnsslAuthenticationRule(d, c.Fv)
+	if err != nil {
+		return fmt.Errorf("error updating VpnsslAuthenticationRule resource while getting object: %v", err)
+	}
+
+	o, err := c.UpdateVpnsslAuthenticationRule(obj, mkey, vdomparam, urlparams, batchid)
+	if err != nil {
+		return fmt.Errorf("error updating VpnsslAuthenticationRule resource: %v", err)
+	}
+
+	log.Printf(strconv.Itoa(c.Retries))
+	if o["mkey"] != nil && o["mkey"] != "" {
+		d.SetId(strconv.Itoa(int(o["mkey"].(float64))))
+	} else {
+		d.SetId("VpnsslAuthenticationRule")
+	}
+
+	return resourceVpnsslAuthenticationRuleRead(d, m)
+}
+
+func resourceVpnsslAuthenticationRuleDelete(d *schema.ResourceData, m interface{}) error {
+	mkey := d.Id()
+
+	c := m.(*FortiClient).Client
+	c.Retries = 1
+
+	vdomparam := ""
+
+	if v, ok := d.GetOk("vdomparam"); ok {
+		if s, ok := v.(string); ok {
+			vdomparam = s
+		}
+	}
+
+	batchid := 0
+
+	if v, ok := d.GetOk("batchid"); ok {
+		if i, ok := v.(int); ok {
+			batchid = i
+		}
+	}
+
+	err := c.DeleteVpnsslAuthenticationRule(mkey, vdomparam, batchid)
+	if err != nil {
+		return fmt.Errorf("error deleting VpnsslAuthenticationRule resource: %v", err)
+	}
+
+	d.SetId("")
+
+	return nil
+}
+
+func resourceVpnsslAuthenticationRuleRead(d *schema.ResourceData, m interface{}) error {
+	mkey := d.Id()
+
+	c := m.(*FortiClient).Client
+	c.Retries = 1
+	urlparams := make(map[string][]string)
+
+	vdomparam := ""
+
+	if v, ok := d.GetOk("vdomparam"); ok {
+		if s, ok := v.(string); ok {
+			vdomparam = s
+		}
+	}
+
+	batchid := 0
+
+	if v, ok := d.GetOk("batchid"); ok {
+		if i, ok := v.(int); ok {
+			batchid = i
+		}
+	}
+
+	o, err := c.ReadVpnsslAuthenticationRule(mkey, vdomparam, urlparams, batchid)
+	if err != nil {
+		return fmt.Errorf("error reading VpnsslAuthenticationRule resource: %v", err)
+	}
+
+	if o == nil {
+		log.Printf("[WARN] resource (%s) not found, removing from state", d.Id())
+		d.SetId("")
+		return nil
+	}
+
+	err = refreshObjectVpnsslAuthenticationRule(d, o, c.Fv)
+	if err != nil {
+		return fmt.Errorf("error reading VpnsslAuthenticationRule resource from API: %v", err)
+	}
+	return nil
+}
+
+func flattenVpnsslAuthenticationRuleAuth(v interface{}, d *schema.ResourceData, pre string, sv string) interface{} {
+	return v
+}
+
+func flattenVpnsslAuthenticationRuleCipher(v interface{}, d *schema.ResourceData, pre string, sv string) interface{} {
+	return v
+}
+
+func flattenVpnsslAuthenticationRuleClientCert(v interface{}, d *schema.ResourceData, pre string, sv string) interface{} {
+	return v
+}
+
+func flattenVpnsslAuthenticationRuleGroups(v interface{}, d *schema.ResourceData, pre string, sv string) []map[string]interface{} {
+	if v == nil {
+		return nil
+	}
+
+	l := v.([]interface{})
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(l))
+
+	con := 0
+	for _, r := range l {
+		tmp := make(map[string]interface{})
+		i := r.(map[string]interface{})
+
+		pre_append := "" // table
+		pre_append = pre + "." + strconv.Itoa(con) + "." + "name"
+		if _, ok := i["name"]; ok {
+
+			tmp["name"] = flattenVpnsslAuthenticationRuleGroupsName(i["name"], d, pre_append, sv)
+		}
+
+		result = append(result, tmp)
+
+		con += 1
+	}
+
+	dynamic_sort_subtable(result, "name", d)
+	return result
+}
+
+func flattenVpnsslAuthenticationRuleGroupsName(v interface{}, d *schema.ResourceData, pre string, sv string) interface{} {
+	return v
+}
+
+func flattenVpnsslAuthenticationRuleId(v interface{}, d *schema.ResourceData, pre string, sv string) interface{} {
+	return v
+}
+
+func flattenVpnsslAuthenticationRulePortal(v interface{}, d *schema.ResourceData, pre string, sv string) interface{} {
+	return v
+}
+
+func flattenVpnsslAuthenticationRuleRealm(v interface{}, d *schema.ResourceData, pre string, sv string) interface{} {
+	return v
+}
+
+func flattenVpnsslAuthenticationRuleSourceAddress(v interface{}, d *schema.ResourceData, pre string, sv string) []map[string]interface{} {
+	if v == nil {
+		return nil
+	}
+
+	l := v.([]interface{})
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(l))
+
+	con := 0
+	for _, r := range l {
+		tmp := make(map[string]interface{})
+		i := r.(map[string]interface{})
+
+		pre_append := "" // table
+		pre_append = pre + "." + strconv.Itoa(con) + "." + "name"
+		if _, ok := i["name"]; ok {
+
+			tmp["name"] = flattenVpnsslAuthenticationRuleSourceAddressName(i["name"], d, pre_append, sv)
+		}
+
+		result = append(result, tmp)
+
+		con += 1
+	}
+
+	dynamic_sort_subtable(result, "name", d)
+	return result
+}
+
+func flattenVpnsslAuthenticationRuleSourceAddressName(v interface{}, d *schema.ResourceData, pre string, sv string) interface{} {
+	return v
+}
+
+func flattenVpnsslAuthenticationRuleSourceAddressNegate(v interface{}, d *schema.ResourceData, pre string, sv string) interface{} {
+	return v
+}
+
+func flattenVpnsslAuthenticationRuleSourceAddress6(v interface{}, d *schema.ResourceData, pre string, sv string) []map[string]interface{} {
+	if v == nil {
+		return nil
+	}
+
+	l := v.([]interface{})
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(l))
+
+	con := 0
+	for _, r := range l {
+		tmp := make(map[string]interface{})
+		i := r.(map[string]interface{})
+
+		pre_append := "" // table
+		pre_append = pre + "." + strconv.Itoa(con) + "." + "name"
+		if _, ok := i["name"]; ok {
+
+			tmp["name"] = flattenVpnsslAuthenticationRuleSourceAddress6Name(i["name"], d, pre_append, sv)
+		}
+
+		result = append(result, tmp)
+
+		con += 1
+	}
+
+	dynamic_sort_subtable(result, "name", d)
+	return result
+}
+
+func flattenVpnsslAuthenticationRuleSourceAddress6Name(v interface{}, d *schema.ResourceData, pre string, sv string) interface{} {
+	return v
+}
+
+func flattenVpnsslAuthenticationRuleSourceAddress6Negate(v interface{}, d *schema.ResourceData, pre string, sv string) interface{} {
+	return v
+}
+
+func flattenVpnsslAuthenticationRuleSourceInterface(v interface{}, d *schema.ResourceData, pre string, sv string) []map[string]interface{} {
+	if v == nil {
+		return nil
+	}
+
+	l := v.([]interface{})
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(l))
+
+	con := 0
+	for _, r := range l {
+		tmp := make(map[string]interface{})
+		i := r.(map[string]interface{})
+
+		pre_append := "" // table
+		pre_append = pre + "." + strconv.Itoa(con) + "." + "name"
+		if _, ok := i["name"]; ok {
+
+			tmp["name"] = flattenVpnsslAuthenticationRuleSourceInterfaceName(i["name"], d, pre_append, sv)
+		}
+
+		result = append(result, tmp)
+
+		con += 1
+	}
+
+	dynamic_sort_subtable(result, "name", d)
+	return result
+}
+
+func flattenVpnsslAuthenticationRuleSourceInterfaceName(v interface{}, d *schema.ResourceData, pre string, sv string) interface{} {
+	return v
+}
+
+func flattenVpnsslAuthenticationRuleUserPeer(v interface{}, d *schema.ResourceData, pre string, sv string) interface{} {
+	return v
+}
+
+func flattenVpnsslAuthenticationRuleUsers(v interface{}, d *schema.ResourceData, pre string, sv string) []map[string]interface{} {
+	if v == nil {
+		return nil
+	}
+
+	l := v.([]interface{})
+	if len(l) == 0 || l[0] == nil {
+		return nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(l))
+
+	con := 0
+	for _, r := range l {
+		tmp := make(map[string]interface{})
+		i := r.(map[string]interface{})
+
+		pre_append := "" // table
+		pre_append = pre + "." + strconv.Itoa(con) + "." + "name"
+		if _, ok := i["name"]; ok {
+
+			tmp["name"] = flattenVpnsslAuthenticationRuleUsersName(i["name"], d, pre_append, sv)
+		}
+
+		result = append(result, tmp)
+
+		con += 1
+	}
+
+	dynamic_sort_subtable(result, "name", d)
+	return result
+}
+
+func flattenVpnsslAuthenticationRuleUsersName(v interface{}, d *schema.ResourceData, pre string, sv string) interface{} {
+	return v
+}
+
+func refreshObjectVpnsslAuthenticationRule(d *schema.ResourceData, o map[string]interface{}, sv string) error {
+	var err error
+
+	if err = d.Set("auth", flattenVpnsslAuthenticationRuleAuth(o["auth"], d, "auth", sv)); err != nil {
+		if !fortiAPIPatch(o["auth"]) {
+			return fmt.Errorf("error reading auth: %v", err)
+		}
+	}
+
+	if err = d.Set("cipher", flattenVpnsslAuthenticationRuleCipher(o["cipher"], d, "cipher", sv)); err != nil {
+		if !fortiAPIPatch(o["cipher"]) {
+			return fmt.Errorf("error reading cipher: %v", err)
+		}
+	}
+
+	if err = d.Set("client_cert", flattenVpnsslAuthenticationRuleClientCert(o["client-cert"], d, "client_cert", sv)); err != nil {
+		if !fortiAPIPatch(o["client-cert"]) {
+			return fmt.Errorf("error reading client_cert: %v", err)
+		}
+	}
+
+	if isImportTable() {
+		if err = d.Set("groups", flattenVpnsslAuthenticationRuleGroups(o["groups"], d, "groups", sv)); err != nil {
+			if !fortiAPIPatch(o["groups"]) {
+				return fmt.Errorf("error reading groups: %v", err)
+			}
+		}
+	} else {
+		if _, ok := d.GetOk("groups"); ok {
+			if err = d.Set("groups", flattenVpnsslAuthenticationRuleGroups(o["groups"], d, "groups", sv)); err != nil {
+				if !fortiAPIPatch(o["groups"]) {
+					return fmt.Errorf("error reading groups: %v", err)
+				}
+			}
+		}
+	}
+
+	if err = d.Set("fosid", flattenVpnsslAuthenticationRuleId(o["id"], d, "fosid", sv)); err != nil {
+		if !fortiAPIPatch(o["id"]) {
+			return fmt.Errorf("error reading fosid: %v", err)
+		}
+	}
+
+	if err = d.Set("portal", flattenVpnsslAuthenticationRulePortal(o["portal"], d, "portal", sv)); err != nil {
+		if !fortiAPIPatch(o["portal"]) {
+			return fmt.Errorf("error reading portal: %v", err)
+		}
+	}
+
+	if err = d.Set("realm", flattenVpnsslAuthenticationRuleRealm(o["realm"], d, "realm", sv)); err != nil {
+		if !fortiAPIPatch(o["realm"]) {
+			return fmt.Errorf("error reading realm: %v", err)
+		}
+	}
+
+	if isImportTable() {
+		if err = d.Set("source_address", flattenVpnsslAuthenticationRuleSourceAddress(o["source-address"], d, "source_address", sv)); err != nil {
+			if !fortiAPIPatch(o["source-address"]) {
+				return fmt.Errorf("error reading source_address: %v", err)
+			}
+		}
+	} else {
+		if _, ok := d.GetOk("source_address"); ok {
+			if err = d.Set("source_address", flattenVpnsslAuthenticationRuleSourceAddress(o["source-address"], d, "source_address", sv)); err != nil {
+				if !fortiAPIPatch(o["source-address"]) {
+					return fmt.Errorf("error reading source_address: %v", err)
+				}
+			}
+		}
+	}
+
+	if err = d.Set("source_address_negate", flattenVpnsslAuthenticationRuleSourceAddressNegate(o["source-address-negate"], d, "source_address_negate", sv)); err != nil {
+		if !fortiAPIPatch(o["source-address-negate"]) {
+			return fmt.Errorf("error reading source_address_negate: %v", err)
+		}
+	}
+
+	if isImportTable() {
+		if err = d.Set("source_address6", flattenVpnsslAuthenticationRuleSourceAddress6(o["source-address6"], d, "source_address6", sv)); err != nil {
+			if !fortiAPIPatch(o["source-address6"]) {
+				return fmt.Errorf("error reading source_address6: %v", err)
+			}
+		}
+	} else {
+		if _, ok := d.GetOk("source_address6"); ok {
+			if err = d.Set("source_address6", flattenVpnsslAuthenticationRuleSourceAddress6(o["source-address6"], d, "source_address6", sv)); err != nil {
+				if !fortiAPIPatch(o["source-address6"]) {
+					return fmt.Errorf("error reading source_address6: %v", err)
+				}
+			}
+		}
+	}
+
+	if err = d.Set("source_address6_negate", flattenVpnsslAuthenticationRuleSourceAddress6Negate(o["source-address6-negate"], d, "source_address6_negate", sv)); err != nil {
+		if !fortiAPIPatch(o["source-address6-negate"]) {
+			return fmt.Errorf("error reading source_address6_negate: %v", err)
+		}
+	}
+
+	if isImportTable() {
+		if err = d.Set("source_interface", flattenVpnsslAuthenticationRuleSourceInterface(o["source-interface"], d, "source_interface", sv)); err != nil {
+			if !fortiAPIPatch(o["source-interface"]) {
+				return fmt.Errorf("error reading source_interface: %v", err)
+			}
+		}
+	} else {
+		if _, ok := d.GetOk("source_interface"); ok {
+			if err = d.Set("source_interface", flattenVpnsslAuthenticationRuleSourceInterface(o["source-interface"], d, "source_interface", sv)); err != nil {
+				if !fortiAPIPatch(o["source-interface"]) {
+					return fmt.Errorf("error reading source_interface: %v", err)
+				}
+			}
+		}
+	}
+
+	if err = d.Set("user_peer", flattenVpnsslAuthenticationRuleUserPeer(o["user-peer"], d, "user_peer", sv)); err != nil {
+		if !fortiAPIPatch(o["user-peer"]) {
+			return fmt.Errorf("error reading user_peer: %v", err)
+		}
+	}
+
+	if isImportTable() {
+		if err = d.Set("users", flattenVpnsslAuthenticationRuleUsers(o["users"], d, "users", sv)); err != nil {
+			if !fortiAPIPatch(o["users"]) {
+				return fmt.Errorf("error reading users: %v", err)
+			}
+		}
+	} else {
+		if _, ok := d.GetOk("users"); ok {
+			if err = d.Set("users", flattenVpnsslAuthenticationRuleUsers(o["users"], d, "users", sv)); err != nil {
+				if !fortiAPIPatch(o["users"]) {
+					return fmt.Errorf("error reading users: %v", err)
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+func expandVpnsslAuthenticationRuleAuth(d *schema.ResourceData, v interface{}, pre string, sv string) (interface{}, error) {
+	return v, nil
+}
+
+func expandVpnsslAuthenticationRuleCipher(d *schema.ResourceData, v interface{}, pre string, sv string) (interface{}, error) {
+	return v, nil
+}
+
+func expandVpnsslAuthenticationRuleClientCert(d *schema.ResourceData, v interface{}, pre string, sv string) (interface{}, error) {
+	return v, nil
+}
+
+func expandVpnsslAuthenticationRuleGroups(d *schema.ResourceData, v interface{}, pre string, sv string) (interface{}, error) {
+	l := v.([]interface{})
+	if len(l) == 0 || l[0] == nil {
+		return nil, nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(l))
+
+	con := 0
+	for _, r := range l {
+		tmp := make(map[string]interface{})
+		i := r.(map[string]interface{})
+		pre_append := "" // table
+
+		pre_append = pre + "." + strconv.Itoa(con) + "." + "name"
+		if _, ok := d.GetOk(pre_append); ok {
+
+			tmp["name"], _ = expandVpnsslAuthenticationRuleGroupsName(d, i["name"], pre_append, sv)
+		}
+
+		result = append(result, tmp)
+
+		con += 1
+	}
+
+	return result, nil
+}
+
+func expandVpnsslAuthenticationRuleGroupsName(d *schema.ResourceData, v interface{}, pre string, sv string) (interface{}, error) {
+	return v, nil
+}
+
+func expandVpnsslAuthenticationRuleId(d *schema.ResourceData, v interface{}, pre string, sv string) (interface{}, error) {
+	return v, nil
+}
+
+func expandVpnsslAuthenticationRulePortal(d *schema.ResourceData, v interface{}, pre string, sv string) (interface{}, error) {
+	return v, nil
+}
+
+func expandVpnsslAuthenticationRuleRealm(d *schema.ResourceData, v interface{}, pre string, sv string) (interface{}, error) {
+	return v, nil
+}
+
+func expandVpnsslAuthenticationRuleSourceAddress(d *schema.ResourceData, v interface{}, pre string, sv string) (interface{}, error) {
+	l := v.([]interface{})
+	if len(l) == 0 || l[0] == nil {
+		return nil, nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(l))
+
+	con := 0
+	for _, r := range l {
+		tmp := make(map[string]interface{})
+		i := r.(map[string]interface{})
+		pre_append := "" // table
+
+		pre_append = pre + "." + strconv.Itoa(con) + "." + "name"
+		if _, ok := d.GetOk(pre_append); ok {
+
+			tmp["name"], _ = expandVpnsslAuthenticationRuleSourceAddressName(d, i["name"], pre_append, sv)
+		}
+
+		result = append(result, tmp)
+
+		con += 1
+	}
+
+	return result, nil
+}
+
+func expandVpnsslAuthenticationRuleSourceAddressName(d *schema.ResourceData, v interface{}, pre string, sv string) (interface{}, error) {
+	return v, nil
+}
+
+func expandVpnsslAuthenticationRuleSourceAddressNegate(d *schema.ResourceData, v interface{}, pre string, sv string) (interface{}, error) {
+	return v, nil
+}
+
+func expandVpnsslAuthenticationRuleSourceAddress6(d *schema.ResourceData, v interface{}, pre string, sv string) (interface{}, error) {
+	l := v.([]interface{})
+	if len(l) == 0 || l[0] == nil {
+		return nil, nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(l))
+
+	con := 0
+	for _, r := range l {
+		tmp := make(map[string]interface{})
+		i := r.(map[string]interface{})
+		pre_append := "" // table
+
+		pre_append = pre + "." + strconv.Itoa(con) + "." + "name"
+		if _, ok := d.GetOk(pre_append); ok {
+
+			tmp["name"], _ = expandVpnsslAuthenticationRuleSourceAddress6Name(d, i["name"], pre_append, sv)
+		}
+
+		result = append(result, tmp)
+
+		con += 1
+	}
+
+	return result, nil
+}
+
+func expandVpnsslAuthenticationRuleSourceAddress6Name(d *schema.ResourceData, v interface{}, pre string, sv string) (interface{}, error) {
+	return v, nil
+}
+
+func expandVpnsslAuthenticationRuleSourceAddress6Negate(d *schema.ResourceData, v interface{}, pre string, sv string) (interface{}, error) {
+	return v, nil
+}
+
+func expandVpnsslAuthenticationRuleSourceInterface(d *schema.ResourceData, v interface{}, pre string, sv string) (interface{}, error) {
+	l := v.([]interface{})
+	if len(l) == 0 || l[0] == nil {
+		return nil, nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(l))
+
+	con := 0
+	for _, r := range l {
+		tmp := make(map[string]interface{})
+		i := r.(map[string]interface{})
+		pre_append := "" // table
+
+		pre_append = pre + "." + strconv.Itoa(con) + "." + "name"
+		if _, ok := d.GetOk(pre_append); ok {
+
+			tmp["name"], _ = expandVpnsslAuthenticationRuleSourceInterfaceName(d, i["name"], pre_append, sv)
+		}
+
+		result = append(result, tmp)
+
+		con += 1
+	}
+
+	return result, nil
+}
+
+func expandVpnsslAuthenticationRuleSourceInterfaceName(d *schema.ResourceData, v interface{}, pre string, sv string) (interface{}, error) {
+	return v, nil
+}
+
+func expandVpnsslAuthenticationRuleUserPeer(d *schema.ResourceData, v interface{}, pre string, sv string) (interface{}, error) {
+	return v, nil
+}
+
+func expandVpnsslAuthenticationRuleUsers(d *schema.ResourceData, v interface{}, pre string, sv string) (interface{}, error) {
+	l := v.([]interface{})
+	if len(l) == 0 || l[0] == nil {
+		return nil, nil
+	}
+
+	result := make([]map[string]interface{}, 0, len(l))
+
+	con := 0
+	for _, r := range l {
+		tmp := make(map[string]interface{})
+		i := r.(map[string]interface{})
+		pre_append := "" // table
+
+		pre_append = pre + "." + strconv.Itoa(con) + "." + "name"
+		if _, ok := d.GetOk(pre_append); ok {
+
+			tmp["name"], _ = expandVpnsslAuthenticationRuleUsersName(d, i["name"], pre_append, sv)
+		}
+
+		result = append(result, tmp)
+
+		con += 1
+	}
+
+	return result, nil
+}
+
+func expandVpnsslAuthenticationRuleUsersName(d *schema.ResourceData, v interface{}, pre string, sv string) (interface{}, error) {
+	return v, nil
+}
+
+func getObjectVpnsslAuthenticationRule(d *schema.ResourceData, sv string) (*map[string]interface{}, error) {
+	obj := make(map[string]interface{})
+
+	if v, ok := d.GetOk("auth"); ok {
+		t, err := expandVpnsslAuthenticationRuleAuth(d, v, "auth", sv)
+		if err != nil {
+			return &obj, err
+		} else if t != nil {
+			obj["auth"] = t
+		}
+	}
+
+	if v, ok := d.GetOk("cipher"); ok {
+		t, err := expandVpnsslAuthenticationRuleCipher(d, v, "cipher", sv)
+		if err != nil {
+			return &obj, err
+		} else if t != nil {
+			obj["cipher"] = t
+		}
+	}
+
+	if v, ok := d.GetOk("client_cert"); ok {
+		t, err := expandVpnsslAuthenticationRuleClientCert(d, v, "client_cert", sv)
+		if err != nil {
+			return &obj, err
+		} else if t != nil {
+			obj["client-cert"] = t
+		}
+	}
+
+	if v, ok := d.GetOk("groups"); ok {
+		t, err := expandVpnsslAuthenticationRuleGroups(d, v, "groups", sv)
+		if err != nil {
+			return &obj, err
+		} else if t != nil {
+			obj["groups"] = t
+		}
+	}
+
+	if v, ok := d.GetOk("fosid"); ok {
+		t, err := expandVpnsslAuthenticationRuleId(d, v, "fosid", sv)
+		if err != nil {
+			return &obj, err
+		} else if t != nil {
+			obj["id"] = t
+		}
+	}
+
+	if v, ok := d.GetOk("portal"); ok {
+		t, err := expandVpnsslAuthenticationRulePortal(d, v, "portal", sv)
+		if err != nil {
+			return &obj, err
+		} else if t != nil {
+			obj["portal"] = t
+		}
+	}
+
+	if v, ok := d.GetOk("realm"); ok {
+		t, err := expandVpnsslAuthenticationRuleRealm(d, v, "realm", sv)
+		if err != nil {
+			return &obj, err
+		} else if t != nil {
+			obj["realm"] = t
+		}
+	}
+
+	if v, ok := d.GetOk("source_address"); ok {
+		t, err := expandVpnsslAuthenticationRuleSourceAddress(d, v, "source_address", sv)
+		if err != nil {
+			return &obj, err
+		} else if t != nil {
+			obj["source-address"] = t
+		}
+	}
+
+	if v, ok := d.GetOk("source_address_negate"); ok {
+		t, err := expandVpnsslAuthenticationRuleSourceAddressNegate(d, v, "source_address_negate", sv)
+		if err != nil {
+			return &obj, err
+		} else if t != nil {
+			obj["source-address-negate"] = t
+		}
+	}
+
+	if v, ok := d.GetOk("source_address6"); ok {
+		t, err := expandVpnsslAuthenticationRuleSourceAddress6(d, v, "source_address6", sv)
+		if err != nil {
+			return &obj, err
+		} else if t != nil {
+			obj["source-address6"] = t
+		}
+	}
+
+	if v, ok := d.GetOk("source_address6_negate"); ok {
+		t, err := expandVpnsslAuthenticationRuleSourceAddress6Negate(d, v, "source_address6_negate", sv)
+		if err != nil {
+			return &obj, err
+		} else if t != nil {
+			obj["source-address6-negate"] = t
+		}
+	}
+
+	if v, ok := d.GetOk("source_interface"); ok {
+		t, err := expandVpnsslAuthenticationRuleSourceInterface(d, v, "source_interface", sv)
+		if err != nil {
+			return &obj, err
+		} else if t != nil {
+			obj["source-interface"] = t
+		}
+	}
+
+	if v, ok := d.GetOk("user_peer"); ok {
+		t, err := expandVpnsslAuthenticationRuleUserPeer(d, v, "user_peer", sv)
+		if err != nil {
+			return &obj, err
+		} else if t != nil {
+			obj["user-peer"] = t
+		}
+	}
+
+	if v, ok := d.GetOk("users"); ok {
+		t, err := expandVpnsslAuthenticationRuleUsers(d, v, "users", sv)
+		if err != nil {
+			return &obj, err
+		} else if t != nil {
+			obj["users"] = t
+		}
+	}
+
+	return &obj, nil
+}

--- a/go.mod
+++ b/go.mod
@@ -7,5 +7,5 @@ require (
 	github.com/google/uuid v1.3.0
 	github.com/hashicorp/go-version v1.3.0
 	github.com/hashicorp/terraform-plugin-sdk v1.17.2
-	github.com/poroping/forti-sdk-go v1.6.0
+	github.com/poroping/forti-sdk-go v1.6.2
 )

--- a/go.sum
+++ b/go.sum
@@ -291,8 +291,8 @@ github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/poroping/forti-sdk-go v1.6.0 h1:2xt+ID/49N941JOUUQby8LNQe9jUQxekG8BFTfz9MdY=
-github.com/poroping/forti-sdk-go v1.6.0/go.mod h1:u/LO40dqrqBsm4sUqwpx449TUgt0Im/O9LH6DqAUVQY=
+github.com/poroping/forti-sdk-go v1.6.2 h1:2P3REJ0V/cDwTIH7z9GLlN1Vy0LCmvVbcwrZlZCEDHg=
+github.com/poroping/forti-sdk-go v1.6.2/go.mod h1:u/LO40dqrqBsm4sUqwpx449TUgt0Im/O9LH6DqAUVQY=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
 github.com/posener/complete v1.2.1 h1:LrvDIY//XNo65Lq84G/akBuMGlawHvGBABv8f/ZN6DI=
 github.com/posener/complete v1.2.1/go.mod h1:6gapUrK/U1TAN7ciCoNRIdVC5sbdBTUh1DKN0g6uH7E=

--- a/vendor/github.com/poroping/forti-sdk-go/fortios/sdkcore/sdkfos.go
+++ b/vendor/github.com/poroping/forti-sdk-go/fortios/sdkcore/sdkfos.go
@@ -25834,3 +25834,57 @@ func (c *FortiSDKClient) ReadFirewallAccessProxyVirtualHost(mkey string, vdompar
 	mapTmp, err = read(c, HTTPMethod, path, false, vdomparam, urlparams, batchid)
 	return
 }
+
+// CreateVpnsslAuthenticationRule API operation for FortiOS creates a new SSL VPN Authentication Rule.
+// Returns the index value of the SSL VPN Authentication Rule and execution result when the request executes successfully.
+// Returns error for service API and SDK errors.
+// See the vpn.ssl settings chapter in the FortiOS Handbook - CLI Reference.
+func (c *FortiSDKClient) CreateVpnsslAuthenticationRule(data *map[string]interface{}, vdomparam string, urlparams map[string][]string, batchid int) (output map[string]interface{}, err error) {
+
+	HTTPMethod := "POST"
+	path := "/api/v2/cmdb/vpn.ssl/settings/authentication-rule"
+	output = make(map[string]interface{})
+
+	err = createUpdate(c, HTTPMethod, path, data, output, vdomparam, urlparams, batchid)
+	return
+}
+
+// UpdateVpnsslAuthenticationRule API operation for FortiOS updates the specified SSL VPN Authentication Rule.
+// Returns the index value of the SSL VPN Authentication Rule and execution result when the request executes successfully.
+// Returns error for service API and SDK errors.
+// See the vpn.ssl settings chapter in the FortiOS Handbook - CLI Reference.
+func (c *FortiSDKClient) UpdateVpnsslAuthenticationRule(data *map[string]interface{}, mkey string, vdomparam string, urlparams map[string][]string, batchid int) (output map[string]interface{}, err error) {
+	HTTPMethod := "PUT"
+	path := "/api/v2/cmdb/vpn.ssl/settings/authentication-rule"
+	path += "/" + escapeURLString(mkey)
+	output = make(map[string]interface{})
+
+	err = createUpdate(c, HTTPMethod, path, data, output, vdomparam, urlparams, batchid)
+	return
+}
+
+// DeleteVpnsslAuthenticationRule API operation for FortiOS deletes the specified SSL VPN Authentication Rule.
+// Returns error for service API and SDK errors.
+// See the vpn.ssl settings chapter in the FortiOS Handbook - CLI Reference.
+func (c *FortiSDKClient) DeleteVpnsslAuthenticationRule(mkey string, vdomparam string, batchid int) (err error) {
+	HTTPMethod := "DELETE"
+	path := "/api/v2/cmdb/vpn.ssl/settings/authentication-rule"
+	path += "/" + escapeURLString(mkey)
+
+	err = delete(c, HTTPMethod, path, vdomparam, batchid)
+	return
+}
+
+// ReadVpnsslAuthenticationRule API operation for FortiOS gets the SSL VPN Authentication Rule
+// with the specified index value.
+// Returns the requested SSL VPN Authentication Rule value when the request executes successfully.
+// Returns error for service API and SDK errors.
+// See the vpn.ssl settings chapter in the FortiOS Handbook - CLI Reference.
+func (c *FortiSDKClient) ReadVpnsslAuthenticationRule(mkey string, vdomparam string, urlparams map[string][]string, batchid int) (mapTmp map[string]interface{}, err error) {
+	HTTPMethod := "GET"
+	path := "/api/v2/cmdb/vpn.ssl/settings/authentication-rule"
+	path += "/" + escapeURLString(mkey)
+
+	mapTmp, err = read(c, HTTPMethod, path, false, vdomparam, urlparams, batchid)
+	return
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -257,7 +257,7 @@ github.com/mitchellh/mapstructure
 github.com/mitchellh/reflectwalk
 # github.com/oklog/run v1.0.0
 github.com/oklog/run
-# github.com/poroping/forti-sdk-go v1.6.0
+# github.com/poroping/forti-sdk-go v1.6.2
 ## explicit
 github.com/poroping/forti-sdk-go/fortios/auth
 github.com/poroping/forti-sdk-go/fortios/config

--- a/website/docs/d/fortios_vpnssl_settings_authentication_rule.html.markdown
+++ b/website/docs/d/fortios_vpnssl_settings_authentication_rule.html.markdown
@@ -1,0 +1,58 @@
+---
+subcategory: "FortiGate Vpn"
+layout: "fortios"
+page_title: "FortiOS: fortios_vpnssl_settings_authentication_rule"
+description: |-
+  Get information on a fortios Authentication rule for SSL VPN.
+---
+
+# Data Source: fortios_vpnssl_settings_authentication_rule
+Use this data source to get information on a fortios Authentication rule for SSL VPN.
+
+## Example Usage
+
+WIP
+
+## Argument Reference
+
+* `fosid` - (Required) ID (0 - 4294967295).
+* `vdomparam` - Specifies the vdom to which the data source will be applied when the FortiGate unit is running in VDOM mode. Only one vdom can be specified. If you want to inherit the vdom configuration of the provider, please do not set this parameter.
+
+## Attribute Reference
+
+The following attributes are exported:
+
+* `auth` - SSL VPN authentication method restriction.
+* `cipher` - SSL VPN cipher strength.
+* `client_cert` - Enable/disable SSL VPN client certificate restrictive.
+* `fosid` - ID (0 - 4294967295).
+* `portal` - SSL VPN portal.
+* `realm` - SSL VPN realm.
+* `source_address_negate` - Enable/disable negated source address match.
+* `source_address6_negate` - Enable/disable negated source IPv6 address match.
+* `user_peer` - Name of user peer.
+* `groups` - User groups.The structure of `groups` block is documented below.
+
+The `groups` block contains:
+
+* `name` - Group name.
+* `source_address` - Source address of incoming traffic.The structure of `source_address` block is documented below.
+
+The `source_address` block contains:
+
+* `name` - Address name.
+* `source_address6` - IPv6 source address of incoming traffic.The structure of `source_address6` block is documented below.
+
+The `source_address6` block contains:
+
+* `name` - IPv6 address name.
+* `source_interface` - SSL VPN source interface of incoming traffic.The structure of `source_interface` block is documented below.
+
+The `source_interface` block contains:
+
+* `name` - Interface name.
+* `users` - User name.The structure of `users` block is documented below.
+
+The `users` block contains:
+
+* `name` - User name.

--- a/website/docs/r/fortios_vpnssl_settings_authentication_rule.html.markdown
+++ b/website/docs/r/fortios_vpnssl_settings_authentication_rule.html.markdown
@@ -1,0 +1,69 @@
+---
+subcategory: "FortiGate Vpn"
+layout: "fortios"
+page_title: "FortiOS: fortios_vpnssl_settings_authentication_rule"
+description: |-
+  Authentication rule for SSL VPN.
+---
+
+## fortios_vpnssl_settings_authentication_rule
+Authentication rule for SSL VPN.
+
+~> This resource is configuring a child table of the parent resource: `fortios_vpnssl_settings`. If this resource is used the parent resource must NOT modify this child table or state inconsistencies will occur.
+
+## Example Usage
+
+WIP
+
+## Argument Reference
+* `vdomparam` - Specifies the vdom to which the data source will be applied when the FortiGate unit is running in VDOM mode. Only one vdom can be specified. If you want to inherit the vdom configuration of the provider, please do not set this parameter.
+* `dynamic_sort_table` - `true` or `false`, set this parameter to `true` when using dynamic for_each + toset to configure and sort sub-tables, if set to `true` static sub-tables must be ordered.
+
+* `auth` - SSL VPN authentication method restriction. Valid values: `any` `local` `radius` `tacacs+` `ldap` .
+* `cipher` - SSL VPN cipher strength. Valid values: `any` `high` `medium` .
+* `client_cert` - Enable/disable SSL VPN client certificate restrictive. Valid values: `enable` `disable` .
+* `fosid` - ID (0 - 4294967295).
+* `portal` - SSL VPN portal. This attribute must reference one of the following datasources: `vpn.ssl.web.portal.name` .
+* `realm` - SSL VPN realm. This attribute must reference one of the following datasources: `vpn.ssl.web.realm.url-path` .
+* `source_address_negate` - Enable/disable negated source address match. Valid values: `enable` `disable` .
+* `source_address6_negate` - Enable/disable negated source IPv6 address match. Valid values: `enable` `disable` .
+* `user_peer` - Name of user peer. This attribute must reference one of the following datasources: `user.peer.name` .
+* `groups` - User groups. The structure of `groups` block is documented below.
+
+The `groups` block contains:
+
+* `name` - Group name. This attribute must reference one of the following datasources: `user.group.name` .
+* `source_address` - Source address of incoming traffic. The structure of `source_address` block is documented below.
+
+The `source_address` block contains:
+
+* `name` - Address name. This attribute must reference one of the following datasources: `firewall.address.name` `firewall.addrgrp.name` `system.external-resource.name` .
+* `source_address6` - IPv6 source address of incoming traffic. The structure of `source_address6` block is documented below.
+
+The `source_address6` block contains:
+
+* `name` - IPv6 address name. This attribute must reference one of the following datasources: `firewall.address6.name` `firewall.addrgrp6.name` `system.external-resource.name` .
+* `source_interface` - SSL VPN source interface of incoming traffic. The structure of `source_interface` block is documented below.
+
+The `source_interface` block contains:
+
+* `name` - Interface name. This attribute must reference one of the following datasources: `system.interface.name` `system.zone.name` .
+* `users` - User name. The structure of `users` block is documented below.
+
+The `users` block contains:
+
+* `name` - User name. This attribute must reference one of the following datasources: `user.local.name` .
+
+## Attribute Reference
+
+In addition to all the above arguments, the following attributes are exported:
+* `id` - an identifier for the resource with format {{name}}.
+
+## Import
+
+Vpn.Ssl can be imported using any of these accepted formats:
+```
+$ export "FORTIOS_IMPORT_TABLE"="true"
+$ terraform import fortios_vpnssl_authentication_rule.labelname {{name}}
+$ unset "FORTIOS_IMPORT_TABLE"
+```


### PR DESCRIPTION
FEATURES:

* **New Resource** `fortios_vpnssl_settings_authentication_rule`
* **Data Source** `fortios_vpnssl_settings_authentication_rule`

IMPROVEMENTS:
* Codegen templates tidied
* Codegen support for childtables
* Codegen support for resources with parent attribute ID. ID is reserved attribute in TF, FOSID is used instead.
* Codegen support for Sensitive attributes (based on attribute type containing "password")